### PR TITLE
xsrf: don't retrieve xsrf token from localstorage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,7 @@
   ],
   "dependencies": {
     "polymer": "^1.4.0",
-    "iron-ajax": "PolymerElements/iron-ajax#^1.2.0",
-    "iron-localstorage": "PolymerElements/iron-localstorage#^1.0.5"
+    "iron-ajax": "PolymerElements/iron-ajax#^1.2.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
-<link rel="import" href="../iron-localstorage/iron-localstorage.html">
 
 <dom-module id="d2l-ajax">
 	<template>
@@ -20,12 +19,6 @@
 			on-iron-ajax-error="onError"
 			on-iron-ajax-request="onRequest"
 			on-iron-ajax-response="onResponse"></iron-ajax>
-
-		<iron-localstorage
-			name="XSRF.Token"
-			value="{{xsrfToken}}"
-			use-raw="true"
-			></iron-localstorage>
 	</template>
 	<script>
 		/* global Promise */

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -29,7 +29,6 @@ describe('smoke test', function() {
 		setXsrfToken(xsrfTokenValue);
 
 		component = fixture('d2l-ajax-fixture');
-		component.$$('iron-localstorage').reload();
 	});
 
 	afterEach(function () {
@@ -50,9 +49,8 @@ describe('smoke test', function() {
 	}
 
 	describe('XSRF request', function () {
-		it('should send a XSRF request when the XSRF token does not exist in local storage', function (done) {
+		it('should send a XSRF request', function (done) {
 			clearXsrfToken();
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -69,21 +67,9 @@ describe('smoke test', function() {
 				});
 		});
 
-		it('should use xsrf token if it exists in local storage', function (done) {
-			setXsrfToken('oh yeah, awesome');
-			component.$$('iron-localstorage').reload();
-
-			component._getXsrfToken()
-				.then(function(xsrfToken) {
-					expect(xsrfToken).to.equal('oh yeah, awesome');
-					done();
-				});
-		});
-
 		it('should fire error event if XSRF request fails', function (done) {
 			clearXsrfToken();
 			component = fixture('absolute-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -164,7 +150,6 @@ describe('smoke test', function() {
 
 		it('should fire error event if auth token request fails', function (done) {
 			component = fixture('absolute-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'POST',
@@ -190,7 +175,6 @@ describe('smoke test', function() {
 
 		it('should send a request with no auth header when url is relative', function (done) {
 			component = fixture('relative-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -207,7 +191,6 @@ describe('smoke test', function() {
 
 		it('should send a request with XSRF header when url is relative', function(done) {
 			component = fixture('relative-put-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -230,7 +213,6 @@ describe('smoke test', function() {
 
 		it('should send a request with auth header when url is absolute', function (done) {
 			component = fixture('absolute-path-fixture');
-			component.$$('iron-localstorage').reload();
 			component.cachedTokens[defaultScope] = authToken;
 
 			server.respondWith(
@@ -247,7 +229,6 @@ describe('smoke test', function() {
 
 		it('should include specified headers in the request', function (done) {
 			component = fixture('custom-headers-fixture');
-			component.$$('iron-localstorage').reload();
 			component.cachedTokens[defaultScope] = authToken;
 
 			server.respondWith(
@@ -265,7 +246,6 @@ describe('smoke test', function() {
 
 		it('should include specified headers in the request for relative path', function (done) {
 			component = fixture('custom-headers-fixture-relative-url');
-			component.$$('iron-localstorage').reload();
 			component.cachedTokens[defaultScope] = authToken;
 
 			server.respondWith(
@@ -283,7 +263,6 @@ describe('smoke test', function() {
 
 		it('should set lastResponse after successful request', function (done) {
 			component = fixture('relative-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -302,7 +281,6 @@ describe('smoke test', function() {
 
 		it('should set lastError after unsuccessful request', function (done) {
 			component = fixture('relative-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',


### PR DESCRIPTION
Some components are renderering quite early, and grabbing the xsrf token from localstorage far before the lms OnInit code has had a chance to update it. This is causing failed requests on first loads by using xsrf tokens from a previous session.

Easiest fix is to simply not reference localstorage at a moment, until we determine a better way to guarantee such timings