### PR TITLE
implement functions to clear out the cache on session change

### DIFF
--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -297,6 +297,16 @@
 					.then(authTokenRequest);
 			},
 			_cacheToken: function (scope, token) {
+				var cachedScopes = JSON.parse(window.sessionStorage.getItem('d2l-ajax-cached-scopes') || '[]');
+				var scopeIndex = cachedScopes.indexOf(scope);
+
+				if (scopeIndex !== -1) {
+					cachedScopes[scopeIndex] = scope;
+				} else {
+					cachedScopes.push(scope);
+				}
+
+				window.sessionStorage.setItem('d2l-ajax-cached-scopes', JSON.stringify(cachedScopes));
 				window.sessionStorage.setItem(scope, JSON.stringify(token));
 				this.cachedTokens[scope] = token;
 			},
@@ -317,10 +327,21 @@
 				}
 			},
 			_resetAuthTokenCaches: function () {
-				this._setCachedTokens(Object.create(null));
-				this._setInFlightRequests(Object.create(null));
+				this._clearCachedTokens();
+				this._clearInFlightRequests();
 			},
-
+			_clearCachedTokens: function() {
+				var cachedScopes = JSON.parse(window.sessionStorage.getItem('d2l-ajax-cached-scopes') || '[]');
+				for(var i = 0; i < cachedScopes.length; i++) {
+					this._cacheToken(cachedScopes[i], null);
+				}
+			},
+			_clearInFlightRequests: function() {
+				for(var i = 0; i < Object.keys(this.inFlightRequests).length; i++) {
+					var scope = this.inFlightRequests[Object.keys(this.inFlightRequests)[i]];
+					delete this.inFlightRequests[scope];
+				}
+			},
 
 			/*
 			 * XSRF Token

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -105,6 +105,7 @@ describe('smoke test', function() {
 	describe('Auth token request', function () {
 		afterEach(function () {
 			delete component.cachedTokens[defaultScope];
+			window.sessionStorage.setItem(defaultScope, null);
 		});
 
 		it('should send an auth token request when auth token does not exist', function (done) {
@@ -145,7 +146,7 @@ describe('smoke test', function() {
 		});
 
 		it('should use sessionStorage token if it exists', function (done) {
-			window.sessionStorage[defaultScope] = JSON.stringify(authToken);
+			window.sessionStorage.setItem(defaultScope, JSON.stringify(authToken));
 			component._getAuthToken()
 				.then(function (token) {
 					expect(token).to.equal(authToken.access_token);
@@ -159,6 +160,30 @@ describe('smoke test', function() {
 				.then(function (token) {
 					expect(token).to.equal(authToken.access_token);
 					done();
+				});
+		});
+
+		it('should not use cached tokens after session change', function(done) {
+			server.respondWith(
+					'POST',
+					'/d2l/lp/auth/oauth2/token',
+					function (req) {
+						req.respond(200, authTokenResponse.headers, JSON.stringify(authTokenResponse.body));
+					});
+			var alternativeToken = {
+				access_token: 'cool beans',
+				expires_at: Number.MAX_VALUE
+			}
+			component._cacheToken(defaultScope, alternativeToken);
+			component._getAuthToken()
+				.then(function (token) {
+					expect(token).to.equal(alternativeToken.access_token);
+					component._onSessionChanged({ key: 'Session.UserId' });
+					component._getAuthToken()
+						.then(function (token) {
+							expect(token).to.equal(authToken.access_token);
+							done();
+						});
 				});
 		});
 


### PR DESCRIPTION
`_setCachedTokens` and `_setInFlightRequests` were not implemented, resulting in scenarios where tokens from previous sessions could be used after a session change. This PR aims to implement clearing the caches and sessionStorage on session change.