### PR TITLE
implement functions to clear out the cache on session change

### DIFF
--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -327,8 +327,9 @@
 				}
 			},
 			_clearInFlightRequests: function() {
-				for(var i = 0; i < Object.keys(this.inFlightRequests).length; i++) {
-					var scope = this.inFlightRequests[Object.keys(this.inFlightRequests)[i]];
+				var inFlightKeys = Object.keys(this.inFlightRequests);
+				for(var i = 0; i < inFlightKeys.length; i++) {
+					var scope = this.inFlightRequests[inFlightKeys[i]];
 					delete this.inFlightRequests[scope];
 				}
 			},

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -323,8 +323,10 @@
 			_clearCachedTokens: function() {
 				var cachedScopes = JSON.parse(window.sessionStorage.getItem('d2l-ajax-cached-scopes') || '[]');
 				for(var i = 0; i < cachedScopes.length; i++) {
-					this._cacheToken(cachedScopes[i], null);
+					window.sessionStorage.removeItem(cachedScopes[i]);
+					delete this.cachedTokens[cachedScopes[i]];
 				}
+				window.sessionStorage.removeItem('d2l-ajax-cached-scopes');
 			},
 			_clearInFlightRequests: function() {
 				var inFlightKeys = Object.keys(this.inFlightRequests);

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -290,6 +290,13 @@
 					.then(authTokenRequest);
 			},
 			_cacheToken: function (scope, token) {
+				var cachedScopes = JSON.parse(window.sessionStorage.getItem('d2l-ajax-cached-scopes') || '[]');
+
+				if (cachedScopes.indexOf(scope) === -1) {
+					cachedScopes.push(scope);
+					window.sessionStorage.setItem('d2l-ajax-cached-scopes', JSON.stringify(cachedScopes));
+				}
+
 				window.sessionStorage.setItem(scope, JSON.stringify(token));
 				this.cachedTokens[scope] = token;
 			},
@@ -310,10 +317,21 @@
 				}
 			},
 			_resetAuthTokenCaches: function () {
-				this._setCachedTokens(Object.create(null));
-				this._setInFlightRequests(Object.create(null));
+				this._clearCachedTokens();
+				this._clearInFlightRequests();
 			},
-
+			_clearCachedTokens: function() {
+				var cachedScopes = JSON.parse(window.sessionStorage.getItem('d2l-ajax-cached-scopes') || '[]');
+				for(var i = 0; i < cachedScopes.length; i++) {
+					this._cacheToken(cachedScopes[i], null);
+				}
+			},
+			_clearInFlightRequests: function() {
+				for(var i = 0; i < Object.keys(this.inFlightRequests).length; i++) {
+					var scope = this.inFlightRequests[Object.keys(this.inFlightRequests)[i]];
+					delete this.inFlightRequests[scope];
+				}
+			},
 
 			/*
 			 * XSRF Token

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -329,8 +329,7 @@
 			_clearInFlightRequests: function() {
 				var inFlightKeys = Object.keys(this.inFlightRequests);
 				for(var i = 0; i < inFlightKeys.length; i++) {
-					var scope = this.inFlightRequests[inFlightKeys[i]];
-					delete this.inFlightRequests[scope];
+					delete this.inFlightRequests[inFlightKeys[i]];
 				}
 			},
 

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -24,6 +24,9 @@
 		/* global Promise */
 		'use strict';
 
+		var D2L_AJAX_CACHED_TOKENS = {},
+			D2L_AJAX_IN_FLIGHT_REQUESTS = {};
+
 		Polymer({
 			is: 'd2l-ajax',
 			properties: {
@@ -90,20 +93,6 @@
 					}
 				},
 				xsrfToken: String,
-				cachedTokens: {
-					type: Object,
-					readOnly: true,
-					value: function() {
-						return {};
-					}
-				},
-				inFlightRequests: {
-					type: Object,
-					readOnly: true,
-					value: function () {
-						return {};
-					}
-				},
 				sessionChangedHandler: {
 					type: Object,
 					readOnly: true,
@@ -236,33 +225,32 @@
 				return Promise
 					.resolve()
 					.then(function () {
-						var cached = JSON.parse(window.sessionStorage.getItem(scope)) || this.cachedTokens[scope];
+						var cached = D2L_AJAX_CACHED_TOKENS[scope];
 
 						if (cached) {
 							if (!this._tokenExpired(cached)) {
 								return cached.access_token;
 							}
 
-							delete this.cachedTokens[scope];
+							delete D2L_AJAX_CACHED_TOKENS[scope];
 						}
-
 						throw new Error('No cached token');
 					}.bind(this));
 			},
 			_getAuthTokenDeDuped: function (scope) {
-				if (!this.inFlightRequests[scope]) {
-					this.inFlightRequests[scope] = this._requestAuthToken(scope)
+				if (!D2L_AJAX_IN_FLIGHT_REQUESTS[scope]) {
+					D2L_AJAX_IN_FLIGHT_REQUESTS[scope] = this._requestAuthToken(scope)
 						.then(function (token) {
-							delete this.inFlightRequests[scope];
+							delete D2L_AJAX_IN_FLIGHT_REQUESTS[scope];
 							return token;
 						}.bind(this))
 						.catch(function (e) {
-							delete this.inFlightRequests[scope];
+							delete D2L_AJAX_IN_FLIGHT_REQUESTS[scope];
 							throw e;
 						}.bind(this));
 				}
 
-				return this.inFlightRequests[scope];
+				return D2L_AJAX_IN_FLIGHT_REQUESTS[scope];
 			},
 			_requestAuthToken: function (scope) {
 				var self = this;
@@ -290,15 +278,7 @@
 					.then(authTokenRequest);
 			},
 			_cacheToken: function (scope, token) {
-				var cachedScopes = JSON.parse(window.sessionStorage.getItem('d2l-ajax-cached-scopes') || '[]');
-
-				if (cachedScopes.indexOf(scope) === -1) {
-					cachedScopes.push(scope);
-					window.sessionStorage.setItem('d2l-ajax-cached-scopes', JSON.stringify(cachedScopes));
-				}
-
-				window.sessionStorage.setItem(scope, JSON.stringify(token));
-				this.cachedTokens[scope] = token;
+				D2L_AJAX_CACHED_TOKENS[scope] = token;
 			},
 			_tokenExpired: function (token) {
 				return this._clock() > token.expires_at;
@@ -321,17 +301,15 @@
 				this._clearInFlightRequests();
 			},
 			_clearCachedTokens: function() {
-				var cachedScopes = JSON.parse(window.sessionStorage.getItem('d2l-ajax-cached-scopes') || '[]');
-				for(var i = 0; i < cachedScopes.length; i++) {
-					window.sessionStorage.removeItem(cachedScopes[i]);
-					delete this.cachedTokens[cachedScopes[i]];
+				var cachedTokenKeys = Object.keys(D2L_AJAX_CACHED_TOKENS);
+				for(var i = 0; i < cachedTokenKeys.length; i++) {
+					delete D2L_AJAX_CACHED_TOKENS[cachedTokenKeys[i]];
 				}
-				window.sessionStorage.removeItem('d2l-ajax-cached-scopes');
 			},
 			_clearInFlightRequests: function() {
-				var inFlightKeys = Object.keys(this.inFlightRequests);
+				var inFlightKeys = Object.keys(D2L_AJAX_IN_FLIGHT_REQUESTS);
 				for(var i = 0; i < inFlightKeys.length; i++) {
-					delete this.inFlightRequests[inFlightKeys[i]];
+					delete D2L_AJAX_IN_FLIGHT_REQUESTS[inFlightKeys[i]];
 				}
 			},
 

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -75,7 +75,7 @@ describe('smoke test', function() {
 
 	describe('Auth token request', function () {
 		afterEach(function () {
-			delete component._resetAuthTokenCaches();
+			component._resetAuthTokenCaches();
 		});
 
 		it('should send an auth token request when auth token does not exist', function (done) {
@@ -170,7 +170,7 @@ describe('smoke test', function() {
 
 	describe('generateRequest', function () {
 		afterEach(function () {
-			delete component._resetAuthTokenCaches();
+			component._resetAuthTokenCaches();
 		});
 
 		it('should send a request with no auth header when url is relative', function (done) {

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -75,8 +75,7 @@ describe('smoke test', function() {
 
 	describe('Auth token request', function () {
 		afterEach(function () {
-			delete component.cachedTokens[defaultScope];
-			window.sessionStorage.setItem(defaultScope, null);
+			delete component._resetAuthTokenCaches();
 		});
 
 		it('should send an auth token request when auth token does not exist', function (done) {
@@ -104,10 +103,10 @@ describe('smoke test', function() {
 					req.respond(200, authTokenResponse.headers, JSON.stringify(authTokenResponse.body));
 				});
 
-			component.cachedTokens[defaultScope] = {
+			component._cacheToken(defaultScope, {
 				access_token: 'token',
 				expires_at: clock() - 1
-			};
+			});
 
 			component._getAuthToken()
 				.then(function(authToken) {
@@ -116,17 +115,8 @@ describe('smoke test', function() {
 				});
 		});
 
-		it('should use sessionStorage token if it exists', function (done) {
-			window.sessionStorage.setItem(defaultScope, JSON.stringify(authToken));
-			component._getAuthToken()
-				.then(function (token) {
-					expect(token).to.equal(authToken.access_token);
-					done();
-				});
-		});
-
 		it('should use cached auth token if it exists', function (done) {
-			component.cachedTokens[defaultScope] = authToken;
+			component._cacheToken(defaultScope, authToken);
 			component._getAuthToken()
 				.then(function (token) {
 					expect(token).to.equal(authToken.access_token);
@@ -180,7 +170,7 @@ describe('smoke test', function() {
 
 	describe('generateRequest', function () {
 		afterEach(function () {
-			delete component.cachedTokens[defaultScope];
+			delete component._resetAuthTokenCaches();
 		});
 
 		it('should send a request with no auth header when url is relative', function (done) {
@@ -223,7 +213,7 @@ describe('smoke test', function() {
 
 		it('should send a request with auth header when url is absolute', function (done) {
 			component = fixture('absolute-path-fixture');
-			component.cachedTokens[defaultScope] = authToken;
+			component._cacheToken(defaultScope, authToken);
 
 			server.respondWith(
 				'GET',
@@ -239,7 +229,7 @@ describe('smoke test', function() {
 
 		it('should include specified headers in the request', function (done) {
 			component = fixture('custom-headers-fixture');
-			component.cachedTokens[defaultScope] = authToken;
+			component._cacheToken(defaultScope, authToken);
 
 			server.respondWith(
 				'GET',
@@ -256,7 +246,7 @@ describe('smoke test', function() {
 
 		it('should include specified headers in the request for relative path', function (done) {
 			component = fixture('custom-headers-fixture-relative-url');
-			component.cachedTokens[defaultScope] = authToken;
+			component._cacheToken(defaultScope, authToken);
 
 			server.respondWith(
 				'GET',


### PR DESCRIPTION
_setCachedTokens and _setInFlightRequests were not implemented, resulting in scenarios where tokens from previous sessions could be used after a session change. This PR aims to implement clearing the caches and sessionStorage on session change.

`sessionStorage` usage has been removed because it proved too dangerous/unreliable. Caching was made global so that it is not unique to all the instances of `d2l-ajax` being used on the page (for example my-courses widget can easily get 20+ of these attached).