### PR TITLE
Restore local storage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
   ],
   "dependencies": {
     "polymer": "^1.4.0",
-    "iron-ajax": "PolymerElements/iron-ajax#^1.2.0"
+    "iron-ajax": "PolymerElements/iron-ajax#^1.4.0",
+    "iron-localstorage": "PolymerElements/iron-localstorage#^1.0.6"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
+<link rel="import" href="../iron-localstorage/iron-localstorage.html">
 
 <dom-module id="d2l-ajax">
 	<template>
@@ -19,6 +20,10 @@
 			on-iron-ajax-error="onError"
 			on-iron-ajax-request="onRequest"
 			on-iron-ajax-response="onResponse"></iron-ajax>
+		<iron-localstorage
+			name="XSRF.Token"
+			value="{{xsrfToken}}"
+			use-raw="true"></iron-localstorage>
 	</template>
 	<script>
 		/* global Promise */

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -29,6 +29,7 @@ describe('d2l-ajax', function() {
 		setXsrfToken(xsrfTokenValue);
 
 		component = fixture('d2l-ajax-fixture');
+		component.$$('iron-localstorage').reload();
 	});
 
 	afterEach(function () {
@@ -49,8 +50,9 @@ describe('d2l-ajax', function() {
 	}
 
 	describe('XSRF request', function () {
-		it('should send a XSRF request', function (done) {
+		it('should send a XSRF request when the XSRF token does not exist in local storage', function (done) {
 			clearXsrfToken();
+			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -67,9 +69,21 @@ describe('d2l-ajax', function() {
 				});
 		});
 
+		it('should use xsrf token if it exists in local storage', function (done) {
+			setXsrfToken('oh yeah, awesome');
+			component.$$('iron-localstorage').reload();
+
+			component._getXsrfToken()
+				.then(function(xsrfToken) {
+					expect(xsrfToken).to.equal('oh yeah, awesome');
+					done();
+				});
+		});
+
 		it('should fire error event if XSRF request fails', function (done) {
 			clearXsrfToken();
 			component = fixture('absolute-path-fixture');
+			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -165,6 +179,7 @@ describe('d2l-ajax', function() {
 
 		it('should fire error event if auth token request fails', function (done) {
 			component = fixture('absolute-path-fixture');
+			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'POST',
@@ -206,6 +221,7 @@ describe('d2l-ajax', function() {
 
 		it('should send a request with XSRF header when url is relative', function(done) {
 			component = fixture('relative-put-fixture');
+			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -228,6 +244,7 @@ describe('d2l-ajax', function() {
 
 		it('should send a request with auth header when url is absolute', function (done) {
 			component = fixture('absolute-path-fixture');
+			component.$$('iron-localstorage').reload();
 			component._cacheToken(defaultScope, authToken);
 
 			server.respondWith(
@@ -244,6 +261,7 @@ describe('d2l-ajax', function() {
 
 		it('should include specified headers in the request', function (done) {
 			component = fixture('custom-headers-fixture');
+			component.$$('iron-localstorage').reload();
 			component._cacheToken(defaultScope, authToken);
 
 			server.respondWith(
@@ -278,6 +296,7 @@ describe('d2l-ajax', function() {
 
 		it('should set lastResponse after successful request', function (done) {
 			component = fixture('relative-path-fixture');
+			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -296,6 +315,7 @@ describe('d2l-ajax', function() {
 
 		it('should set lastError after unsuccessful request', function (done) {
 			component = fixture('relative-path-fixture');
+			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',


### PR DESCRIPTION
@omsmith, @CodeBaboon: this goes along with the changes to the monolith to output the XSRF token earlier in the JS pipeline. This won't get merged/adopted until those changes are in.