### PR TITLE
replace icon-localstorage with manual localstorage manipulation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,7 @@
   ],
   "dependencies": {
     "polymer": "^1.4.0",
-    "iron-ajax": "PolymerElements/iron-ajax#^1.4.0",
-    "iron-localstorage": "PolymerElements/iron-localstorage#^1.0.6"
+    "iron-ajax": "PolymerElements/iron-ajax#^1.4.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
-<link rel="import" href="../iron-localstorage/iron-localstorage.html">
 
 <dom-module id="d2l-ajax">
 	<template>
@@ -20,10 +19,6 @@
 			on-iron-ajax-error="onError"
 			on-iron-ajax-request="onRequest"
 			on-iron-ajax-response="onResponse"></iron-ajax>
-		<iron-localstorage
-			name="XSRF.Token"
-			value="{{xsrfToken}}"
-			use-raw="true"></iron-localstorage>
 	</template>
 	<script>
 		/* global Promise */
@@ -97,7 +92,6 @@
 						return null;
 					}
 				},
-				xsrfToken: String,
 				sessionChangedHandler: {
 					type: Object,
 					readOnly: true,
@@ -323,12 +317,18 @@
 			 */
 
 			_getXsrfToken: function() {
-				if (this.xsrfToken) {
-					return Promise.resolve(this.xsrfToken);
+
+				try {
+					var xsrfToken = window.localStorage.getItem('XSRF.Token');
+				} catch (e) {
+					// likely private browsing mode, continue anyway
 				}
 
-				var self = this,
-					xsrfRequest = document.createElement('iron-request');
+				if (xsrfToken) {
+					return Promise.resolve(xsrfToken);
+				}
+
+				var xsrfRequest = document.createElement('iron-request');
 
 				var request = xsrfRequest
 					.send({
@@ -337,7 +337,11 @@
 						withCredentials: true
 					})
 					.then(function(res) {
-						self.set('xsrfToken', res.response.referrerToken);
+						try {
+							window.localStorage.setItem('XSRF.Token', res.response.referrerToken);
+						} catch (e) {
+							// likely private browsing mode, continue anyway
+						}
 						return res.response.referrerToken;
 					});
 

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -29,7 +29,6 @@ describe('d2l-ajax', function() {
 		setXsrfToken(xsrfTokenValue);
 
 		component = fixture('d2l-ajax-fixture');
-		component.$$('iron-localstorage').reload();
 	});
 
 	afterEach(function () {
@@ -52,7 +51,6 @@ describe('d2l-ajax', function() {
 	describe('XSRF request', function () {
 		it('should send a XSRF request when the XSRF token does not exist in local storage', function (done) {
 			clearXsrfToken();
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -64,14 +62,12 @@ describe('d2l-ajax', function() {
 			component._getXsrfToken()
 				.then(function(xsrfToken) {
 					expect(xsrfToken).to.equal(xsrfResponse.body.referrerToken);
-					expect(component.xsrfToken).to.equal(xsrfResponse.body.referrerToken);
 					done();
 				});
 		});
 
 		it('should use xsrf token if it exists in local storage', function (done) {
 			setXsrfToken('oh yeah, awesome');
-			component.$$('iron-localstorage').reload();
 
 			component._getXsrfToken()
 				.then(function(xsrfToken) {
@@ -83,7 +79,6 @@ describe('d2l-ajax', function() {
 		it('should fire error event if XSRF request fails', function (done) {
 			clearXsrfToken();
 			component = fixture('absolute-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -179,7 +174,6 @@ describe('d2l-ajax', function() {
 
 		it('should fire error event if auth token request fails', function (done) {
 			component = fixture('absolute-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'POST',
@@ -221,7 +215,6 @@ describe('d2l-ajax', function() {
 
 		it('should send a request with XSRF header when url is relative', function(done) {
 			component = fixture('relative-put-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -244,7 +237,6 @@ describe('d2l-ajax', function() {
 
 		it('should send a request with auth header when url is absolute', function (done) {
 			component = fixture('absolute-path-fixture');
-			component.$$('iron-localstorage').reload();
 			component._cacheToken(defaultScope, authToken);
 
 			server.respondWith(
@@ -261,7 +253,6 @@ describe('d2l-ajax', function() {
 
 		it('should include specified headers in the request', function (done) {
 			component = fixture('custom-headers-fixture');
-			component.$$('iron-localstorage').reload();
 			component._cacheToken(defaultScope, authToken);
 
 			server.respondWith(
@@ -296,7 +287,6 @@ describe('d2l-ajax', function() {
 
 		it('should set lastResponse after successful request', function (done) {
 			component = fixture('relative-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',
@@ -315,7 +305,6 @@ describe('d2l-ajax', function() {
 
 		it('should set lastError after unsuccessful request', function (done) {
 			component = fixture('relative-path-fixture');
-			component.$$('iron-localstorage').reload();
 
 			server.respondWith(
 				'GET',


### PR DESCRIPTION
@omsmith @CodeBaboon @ryantmer 

While testing the latest attempt to reuse local storage as a cache for the XSRF token, we discovered that the `iron-localstorage` WC runs too slowly in IE and hasn't had a chance to initialize before the first XHR calls occurs that needs it. This results in the token never being there in time and IE always making an extra XHR to fetch it.

Decided to just remove `iron-localstorage` and get/set the token manually in local storage. It's a fair bit faster and actually seems simpler.

Future enhancement that I'll create an issue for: if local storage isn't available (the user might be in private browsing mode), use a local page cache using a global object on the window or something.