### PR TITLE
Update readme with soft-deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+> Note: This repo is largely deprecated, in favour of [d2l-fetch](https://github.com/Brightspace/d2l-fetch).
 
 # d2l-ajax
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Note: This repo is largely deprecated, in favour of [d2l-fetch](https://github.com/Brightspace/d2l-fetch).
+> Note: This component is deprecated, please use [d2l-fetch](https://github.com/Brightspace/d2l-fetch) instead.
 
 # d2l-ajax
 


### PR DESCRIPTION
Most use cases where we were using this repo have now been switched to use `d2l-fetch` instead, and we generally want to prevent new usages of this component.